### PR TITLE
Change start of ElasticMq from rest only to server+rest for backwards compatibility (i.e: python boto)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def project-version "1.0.0-SNAPSHOT")
+(def project-version "1.0.1-SNAPSHOT")
 (def build-meta (str "YOPA " project-version " - built on: " (java.util.Date.)))
 (def ring-version "1.3.2")
 (def aws-sdk-version "1.10.5.1")
@@ -37,8 +37,8 @@
    [circleci/clj-yaml "0.5.3"]
    [de.ubercode.clostache/clostache "1.4.0"]
 
-   [org.elasticmq/elasticmq-server_2.11 "0.8.8" :exclusions [joda-time]]
-   [org.elasticmq/elasticmq-rest-sqs_2.11 "0.8.8" :exclusions [joda-time]]
+   [org.elasticmq/elasticmq-server_2.11 "0.8.12" :exclusions [joda-time]]
+   [org.elasticmq/elasticmq-rest-sqs_2.11 "0.8.12" :exclusions [joda-time]]
    [amazonica "0.3.29" :exclusions [com.amazonaws/aws-java-sdk]]
    [com.amazonaws/aws-java-sdk-sqs ~aws-sdk-version :exclusions [joda-time]]
    [com.amazonaws/aws-java-sdk-sns ~aws-sdk-version :exclusions [joda-time]]
@@ -54,9 +54,7 @@
    [ring/ring-core ~ring-version]
    [ring/ring-jetty-adapter ~ring-version]
 
-   [org.jruby/jruby "9.0.0.0" :exclusions [com.github.jnr/jffi
-                                           com.github.jnr/jnr-x86asm
-                                           joda-time]]
+   [org.jruby/jruby "9.0.0.0" :exclusions [joda-time]]
   ]
 
   :repositories

--- a/project.clj
+++ b/project.clj
@@ -37,6 +37,7 @@
    [circleci/clj-yaml "0.5.3"]
    [de.ubercode.clostache/clostache "1.4.0"]
 
+   [org.elasticmq/elasticmq-server_2.11 "0.8.8" :exclusions [joda-time]]
    [org.elasticmq/elasticmq-rest-sqs_2.11 "0.8.8" :exclusions [joda-time]]
    [amazonica "0.3.29" :exclusions [com.amazonaws/aws-java-sdk]]
    [com.amazonaws/aws-java-sdk-sqs ~aws-sdk-version :exclusions [joda-time]]

--- a/src/com/unbounce/yopa/sqs_server.clj
+++ b/src/com/unbounce/yopa/sqs_server.clj
@@ -11,12 +11,21 @@
            com.typesafe.config.Config))
 
 (def config-string "{
+    \"akka.http.server.parsing.illegal-header-warnings\": \"off\",
+    \"akka\": {
+        \"loggers\": [\"akka.event.slf4j.Slf4jLogger\"],
+        \"loglevel\": \"DEBUG\",
+        \"logging-filter\": \"akka.event.slf4j.Slf4jLoggingFilter\",
+        \"log-dead-letters-during-shutdown\": false
+    }
+   \"akka.http.server.request-timeout\": \"21 s\",
+   \"akka.http.server.parsing.max-uri-length\": \"256k\",
    \"storage\":  {
       \"type\" = \"in-memory\"
    },
    \"node-address\":{
       \"protocol\":\"http\",
-      \"host\":\"localhost\",
+      \"host\":\"0.0.0.0\",
       \"port\":\"47195\",
       \"context-path\":\"\"
    },
@@ -24,7 +33,7 @@
       \"enabled\":\"true\",
       \"bind-port\":\"47195\",
       \"bind-hostname\":\"0.0.0.0\",
-      \"sqs-limits\":\"strict\"
+      \"sqs-limits\":\"relaxed\"
    }
 }")
 

--- a/src/com/unbounce/yopa/sqs_server.clj
+++ b/src/com/unbounce/yopa/sqs_server.clj
@@ -3,9 +3,38 @@
             [amazonica.aws.sqs :as sqs]
             [clojure.tools.logging :as log])
   (:import org.elasticmq.rest.sqs.SQSRestServerBuilder
-           org.elasticmq.NodeAddress))
+           org.elasticmq.server.ElasticMQServer
+           org.elasticmq.server.ElasticMQServerConfig
+           org.elasticmq.NodeAddress
+           com.typesafe.config.ConfigObject
+           com.typesafe.config.ConfigFactory
+           com.typesafe.config.Config))
+
+(def config-string "{
+   \"storage\":  {
+      \"type\" = \"in-memory\"
+   },
+   \"node-address\":{
+      \"protocol\":\"http\",
+      \"host\":\"localhost\",
+      \"port\":\"47195\",
+      \"context-path\":\"\"
+   },
+   \"rest-sqs\":{
+      \"enabled\":\"true\",
+      \"bind-port\":\"47195\",
+      \"bind-hostname\":\"0.0.0.0\",
+      \"sqs-limits\":\"strict\"
+   }
+}")
 
 (def ^:private ^:dynamic server (atom nil))
+
+(defn- make-main-server []
+  (let [typesafe-config (ConfigFactory/parseString config-string)]
+  (let [config (ElasticMQServerConfig. typesafe-config)]
+  (-> (ElasticMQServer. config)
+    (.start)))))
 
 (defn- make-server [host bind-address port]
   (let [address (NodeAddress. "http", host, port, "")]
@@ -16,8 +45,7 @@
     (.start))))
 
 (defn start [host bind-address port]
-  (reset! server (make-server host bind-address port))
-  (.waitUntilStarted @server)
+  (reset! server (make-main-server))
   (log/info (format "Active SQS endpoint: http://%s:%d" bind-address port)))
 
 (defn stop []

--- a/src/com/unbounce/yopa/sqs_server.clj
+++ b/src/com/unbounce/yopa/sqs_server.clj
@@ -2,11 +2,8 @@
   (:require [amazonica.core :as aws]
             [amazonica.aws.sqs :as sqs]
             [clojure.tools.logging :as log])
-  (:import org.elasticmq.rest.sqs.SQSRestServerBuilder
-           org.elasticmq.server.ElasticMQServer
+  (:import org.elasticmq.server.ElasticMQServer
            org.elasticmq.server.ElasticMQServerConfig
-           org.elasticmq.NodeAddress
-           com.typesafe.config.ConfigObject
            com.typesafe.config.ConfigFactory
            com.typesafe.config.Config))
 
@@ -17,44 +14,39 @@
         \"loglevel\": \"DEBUG\",
         \"logging-filter\": \"akka.event.slf4j.Slf4jLoggingFilter\",
         \"log-dead-letters-during-shutdown\": false
-    }
+    },
    \"akka.http.server.request-timeout\": \"21 s\",
    \"akka.http.server.parsing.max-uri-length\": \"256k\",
    \"storage\":  {
-      \"type\" = \"in-memory\"
+      \"type\": \"in-memory\"
    },
-   \"node-address\":{
-      \"protocol\":\"http\",
-      \"host\":\"0.0.0.0\",
-      \"port\":\"47195\",
-      \"context-path\":\"\"
+   \"node-address\": {
+      \"protocol\": \"http\",
+      \"host\": \"%s\",
+      \"port\": \"%d\",
+      \"context-path\": \"\"
    },
-   \"rest-sqs\":{
-      \"enabled\":\"true\",
-      \"bind-port\":\"47195\",
-      \"bind-hostname\":\"0.0.0.0\",
-      \"sqs-limits\":\"relaxed\"
-   }
+   \"rest-sqs\": {
+      \"enabled\": true,
+      \"bind-hostname\": \"%s\",
+      \"bind-port\": \"%d\",
+      \"sqs-limits\": \"relaxed\"
+   },
+   \"queues\": {}
 }")
 
 (def ^:private ^:dynamic server (atom nil))
 
-(defn- make-main-server []
-  (let [typesafe-config (ConfigFactory/parseString config-string)]
+(defn- make-main-server [host bind-address port]
+  (let [formatted-config (format config-string host port bind-address port)]
+  (log/info formatted-config)
+  (let [typesafe-config (ConfigFactory/parseString formatted-config)]
   (let [config (ElasticMQServerConfig. typesafe-config)]
   (-> (ElasticMQServer. config)
-    (.start)))))
-
-(defn- make-server [host bind-address port]
-  (let [address (NodeAddress. "http", host, port, "")]
-  (-> (SQSRestServerBuilder/withPort port)
-    (.withInterface bind-address)
-    (.withPort port)
-    (.withServerAddress address)
-    (.start))))
+    (.start))))))
 
 (defn start [host bind-address port]
-  (reset! server (make-main-server))
+  (reset! server (make-main-server host bind-address port))
   (log/info (format "Active SQS endpoint: http://%s:%d" bind-address port)))
 
 (defn stop []

--- a/src/com/unbounce/yopa/sqs_server.clj
+++ b/src/com/unbounce/yopa/sqs_server.clj
@@ -3,9 +3,38 @@
             [amazonica.aws.sqs :as sqs]
             [clojure.tools.logging :as log])
   (:import org.elasticmq.rest.sqs.SQSRestServerBuilder
-           org.elasticmq.NodeAddress))
+           org.elasticmq.server.ElasticMQServer
+           org.elasticmq.server.ElasticMQServerConfig
+           org.elasticmq.NodeAddress
+           com.typesafe.config.ConfigObject
+           com.typesafe.config.ConfigFactory
+           com.typesafe.config.Config))
+
+(def config-string "{
+   \"storage\":  {
+      \"type\" = \"in-memory\"
+   },
+   \"node-address\":{
+      \"protocol\":\"http\",
+      \"host\":\"localhost\",
+      \"port\":\"47195\",
+      \"context-path\":\"\"
+   },
+   \"rest-sqs\":{
+      \"enabled\":\"true\",
+      \"bind-port\":\"47195\",
+      \"bind-hostname\":\"0.0.0.0\",
+      \"sqs-limits\":\"strict\"
+   }
+}")
 
 (def ^:private ^:dynamic server (atom nil))
+
+(defn- make-main-server []
+  (let [typesafe-config (ConfigFactory/parseString config-string)]
+  (let [config (ElasticMQServerConfig. typesafe-config)]
+  (-> (ElasticMQServer. config)
+    (.start)))))
 
 (defn- make-server [host bind-address port]
   (let [address (NodeAddress. "http", host, port, "")]
@@ -16,11 +45,9 @@
     (.start))))
 
 (defn start [host bind-address port]
-  (reset! server (make-server host bind-address port))
-  (.waitUntilStarted @server)
+  (reset! server (make-main-server))
   (log/info (format "Active SQS endpoint: http://%s:%d" bind-address port)))
 
 (defn stop []
   (when @server
-    (.stopAndWait @server)
     (reset! server nil)))


### PR DESCRIPTION
When testing with Celery Event Processor (CEP), we realized that it could not see any queues - we traced this to the fact the yopa only started the REST interface from ElasticMQ so we made the changes to start with "ElasticMQServer" instead.
