### PR TITLE
Bump FakeS3 to 0.2.5

### DIFF
--- a/fake-s3-pom.xml
+++ b/fake-s3-pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>rubygems</groupId>
             <artifactId>fakes3</artifactId>
-            <version>0.2.1</version>
+            <version>0.2.5</version>
             <type>gem</type>
         </dependency>
     </dependencies>

--- a/src/com/unbounce/yopa/s3_server.clj
+++ b/src/com/unbounce/yopa/s3_server.clj
@@ -23,7 +23,7 @@
   [host bind-address port data-dir]
   (str
     "require 'fakes3' \n"
-    "store = FakeS3::FileStore.new('" data-dir "') \n"
+    "store = FakeS3::FileStore.new('" data-dir "', false) \n"
     "webrick_config = { :BindAddress => '" bind-address "'"
                      ", :Port        => " port
                      ", :AccessLog   => [] } \n"


### PR DESCRIPTION
This is the latest version before the change in licensing.